### PR TITLE
docs: README locality pattern + fix outdated paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ InfiniClaw is a multi-agent orchestration system that operates a fleet of autono
 
 ## Quick start
 
-1. Configure secrets (env files) at `~/.config/infiniclaw/secrets/bots/{persona}/env`
+1. Configure secrets (env files) at `~/.config/infiniclaw/secrets/bots/{bot}/env`
 
-2. Configure `~/.config/infiniclaw/machine.json` with which bots run on this machine
+2. Register this machine in `fleet.json` and assign bots (see secrets repo `README.md`)
 
 3. Build container images:
 
 ```bash
-./bots/container/build.sh all
+./bots/build.sh all
 ```
 
 4. Start all bots:
@@ -51,7 +51,7 @@ npm run cli chat johnny5
 
 ### What start/stop do
 
-**`start`** — For each bot in `machine.json`:
+**`start`** — For each bot in `fleet.json` assigned to this ship:
 1. Rsyncs the core library into `_runtime/instances/{bot}/core/`
 2. Appends the bot's persona CLAUDE.md to the base instructions
 3. Sets up persistent room context
@@ -76,36 +76,15 @@ Supports Anthropic (Claude), Ollama (local models), and any OpenAI-compatible AP
 
 Bot identity is defined in three layers of CLAUDE.md:
 
-1. **Base** (`core/CLAUDE.md`) — framework behavior, shared by all bots
-2. **Persona** (`bots/personas/{bot}/CLAUDE.md`) — identity, rules, style (two-way sync: bot can edit)
-3. **Group** (`groups/{group}/CLAUDE.md`) — room-specific context (one-way: repo to bot, read-only)
+1. **Base** (`external/nanoclaw/CLAUDE.md`) — framework behavior, shared by all bots
+2. **Persona** (`bots/{role}/{bot}/CLAUDE.md`) — identity, rules, style (writable by bot)
+3. **Room** (`bots/{role}/ROOM.md`) — room-specific context (read-only)
 
-Each persona also includes:
-- `skills/` — bot-specific skills (two-way sync)
-- `mcp-servers/` — bot-specific MCP servers (two-way sync)
-- `container-config.json` — additional mounts and MCP server declarations
-
-## Directory structure
-
-```
-src/                              InfiniClaw orchestrator source
-external/nanoclaw/                Core mechanics library
-bots/
-  roles/{role}/                   Abstract capability sets
-  personas/{persona}/             Concrete bot identities
-  container/{persona}/Dockerfile  Per-bot container image
-  container/build.sh              Build container images
-groups/                           Group working directories (mounted into containers)
-docs/
-  design/                         Architecture and design documents
-  faq/                            Frequently asked questions
-  assets/                         Images, banners
-_runtime/                         Local state (SQLite, sessions, IPC, logs)
-```
+See `bots/README.md` for full structure.
 
 ## Design
 
-See [`docs/design/00-overview.md`](docs/design/00-overview.md) for architecture, security model, and operations.
+See [`docs/design/README.md`](docs/design/README.md) for the architecture document index.
 
 ## Notes
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -1,24 +1,24 @@
 # bots/
 
-```
-bots/
-├── {role}/                 One directory per role (navigator, engineer, architect)
-│   ├── ROOM.md             Shared room context (mounted ro at /workspace/CLAUDE.md)
-│   ├── skills.json         Skills assigned to this role
-│   ├── mcp.json            MCP servers for this role
-│   └── {bot}/              Bot persona
-│       ├── CLAUDE.md       Identity and rules (mounted rw at /workspace/persona/CLAUDE.md)
-│       └── container-config.json  Extra mounts and container settings
-├── skills/                 Shared skill pool
-│   └── {name}/SKILL.md
-└── container/              Container images
-    ├── build.sh
-    └── {bot}/Dockerfile
-```
+Bot personas, roles, skills, and container definitions.
+
+- `CLAUDE.md` — Shared bot instructions (writable by bots)
+- `build.sh` — Container image build script (`./bots/build.sh all` or `./bots/build.sh <bot>`)
+- `{role}/` — One directory per role (navigator, engineer, architect)
+- `skills/` — Shared skill pool (see `skills/README.md`)
 
 ## Role directories
 
-Each role has a room, skills, and MCP config shared by all bots of that role. Bots are assigned to roles via `roster.json` in the secrets repo.
+Each role directory contains shared config and per-bot personas:
+
+- `ROOM.md` — Room context (read-only in containers)
+- `skills.json` — Skills assigned to this role
+- `mcp.json` — MCP servers for this role
+- `{bot}/CLAUDE.md` — Bot identity and rules (writable by bot)
+- `{bot}/Dockerfile` — Container image definition
+- `{bot}/container-config.json` — Extra mounts and container settings
+
+Bots are assigned to roles via `fleet.json` in the secrets repo.
 
 ## CLAUDE.md layers
 
@@ -28,4 +28,4 @@ Each role has a room, skills, and MCP config shared by all bots of that role. Bo
 
 ## Memory
 
-Bot memory lives in the secrets repo (`~/.config/infiniclaw/secrets/{bot}/memory/`), mounted writable at `/workspace/persona/memory/`.
+Bot memory lives in the secrets repo (`~/.config/infiniclaw/secrets/bots/{bot}/memory/`), mounted writable at `/workspace/persona/memory/`.

--- a/bots/skills/README.md
+++ b/bots/skills/README.md
@@ -1,0 +1,5 @@
+# bots/skills/
+
+Shared skill pool. Each skill is a directory containing a `SKILL.md` that defines the skill's behavior. Skills are assigned to roles via `bots/{role}/skills.json`.
+
+Skills are synced into container sessions at bot startup by `src/skill-sync.ts`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# docs/
+
+Project documentation. Not executable, not imported — reference only.
+
+- `design/` — Architecture and design documents
+- `faq/` — Frequently asked questions (operational how-tos)
+- `assets/` — Images, banners, static media
+- `BUGS.md` — Known issues with priority and status
+- `NEXT.md` — Roadmap, Captain directives, planned work
+- `LESSONS_LEARNED.md` — Retrospective insights from operations

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,23 @@
+# docs/design/
+
+Architecture and design specifications for InfiniClaw. Each numbered document covers one subsystem. Read `00-overview.md` first for context.
+
+- `00-overview.md` — System overview, principles, architecture
+- `01-messaging.md` — Matrix messaging layer, routing, filtering
+- `02-threading.md` — Branch and Merge model, Thread Brains, lobes
+- `03-ipc.md` — Inter-process communication (container to host)
+- `04-fleet.md` — Fleet architecture: rooms, ships, roles, ranks
+- `05-commanding-officer.md` — CO election and manager role
+- `06-commands.md` — Operator `!` commands and relay protocol
+- `07-intercom.md` — Cross-room relay accounts, operator messaging
+- `08-autonomy.md` — Bot self-healing, rebuilds, holodeck
+- `09-configuration.md` — CLAUDE.md layers, MCP, brain, session continuity
+- `10-safety.md` — OOM handling, rate limits, isolation, MCP preflight
+- `11-containers.md` — Podman isolation, mounts, secrets
+- `12-deployment-chain.md` — Worktree workflow, holodeck simulation, gates
+- `13-infrastructure-redundancy.md` — Ships as VMs, Gitea/MinIO redundancy
+- `14-quarters.md` — Ship spaces, bot rooms, lifecycle commands
+- `15-bartender.md` — Bartender skill
+- `IMPLEMENTATION_ROADMAP.md` — Feature roadmap with implementation status
+
+Engineers cannot modify these files (enforced by pre-commit hook). Architecture changes go through the Architect role.

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,0 +1,8 @@
+# docs/faq/
+
+Operational how-tos and troubleshooting guides.
+
+- `health.md` — Health monitoring and diagnostics
+- `operator.md` — Operator procedures and common tasks
+- `runtime-files.md` — Runtime file locations and layout
+- `s3.md` — S3 configuration and usage

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+# scripts/
+
+Operational shell scripts run on the host. Not imported by TypeScript — invoked directly or via npm scripts.
+
+- `rebuild.sh` — Build script (`npm install` + `tsc`), called by `npm run build`
+- `fleet-health.sh` — Fleet health reporting
+- `health-check.sh` — Individual bot health diagnostics
+- `health-history.sh` — Historical health data
+- `metrics-report.sh` — Metrics collection
+- `session-cleanup.sh` — Clean up old session files
+- `setup-minio.sh` — MinIO/S3 initialization
+- `hooks/` — Git hooks (pre-commit, pre-push)

--- a/scripts/hooks/infiniclaw-pre-commit
+++ b/scripts/hooks/infiniclaw-pre-commit
@@ -18,7 +18,38 @@ if echo "$staged" | grep -q 'node_modules/'; then
   exit 1
 fi
 
-# ── Role-based restrictions (ASSISTANT_ROLE set inside containers) ──
+# ── README sibling rule ──
+# Any change to a non-README sibling must include a change to the directory's README.md.
+
+readme_missing=()
+while IFS= read -r file; do
+  dir=$(dirname "$file")
+  base=$(basename "$file")
+  [[ "$base" == "README.md" ]] && continue
+  readme="$dir/README.md"
+  [[ ! -f "$readme" ]] && continue
+  if ! echo "$staged" | grep -qF "$readme"; then
+    readme_missing+=("$readme (changed $file)")
+  fi
+done <<< "$staged"
+
+if [[ ${#readme_missing[@]} -gt 0 ]]; then
+  # Deduplicate by README path
+  seen=()
+  for entry in "${readme_missing[@]}"; do
+    readme_path="${entry%% (*}"
+    skip=false
+    for s in "${seen[@]+"${seen[@]}"}"; do
+      [[ "$s" == "$readme_path" ]] && skip=true && break
+    done
+    $skip && continue
+    seen+=("$readme_path")
+  done
+  echo "ERROR: The following README.md files must be updated when changing siblings:"
+  printf "  %s\n" "${seen[@]}"
+  echo "Stage the README.md changes or use --no-verify to bypass."
+  exit 1
+fi
 
 # ── Role-based restrictions (ASSISTANT_ROLE set inside containers) ──
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,7 +6,7 @@ Standalone utilities for host-side use. No compilation required.
 
 MCP server that reads conversation history from S3.
 
-**Requires**: S3 configured in `~/.config/infiniclaw/machine.json`
+**Requires**: S3 configured in `fleet.json` (secrets repo)
 
 **Add to your `~/.claude/claude_desktop_config.json` or `.mcp.json`:**
 ```json


### PR DESCRIPTION
## Summary

### Commit 1: README locality pattern + fix outdated paths
- **README locality**: Added `README.md` to every directory that lacked one (`docs/`, `docs/design/`, `docs/faq/`, `scripts/`, `bots/skills/`, `external/`). Each README describes what belongs in that directory — siblings only, no up/down.
- **Pre-commit enforcement**: New hook rule requires any commit that changes a sibling of a README.md to also update that README.md.
- **Fix outdated paths**: `machine.json` → `fleet.json`, `bots/personas/` → `bots/{role}/{bot}/`, `roster.json` → `fleet.json`, `docs/DESIGN.md` → `docs/design/README.md`.

### Commit 2: Strip nanoclaw fork to pure TS library
- **Deleted 215 files (~38K lines)** of non-library artifacts from `external/nanoclaw/`: CLAUDE.md, skills, skills-engine, MCP config, container defs, setup wizards, docs, CI, launchd, assets.
- **Kept only**: `src/`, `dist/`, `package.json`, `tsconfig.json`, `vitest.config.ts` — the TypeScript library.
- **Added `external/README.md`** documenting the fork strategy: nanoclaw is a pure code dependency, InfiniClaw owns all non-library concerns (instructions, skills, MCP, containers).
- **Updated CLAUDE.md layer references**: base layer is now `bots/CLAUDE.md` everywhere (README, bots/README, docs/design/09-configuration.md).

### Separate: Slim operator CLAUDE.md (secrets repo, commit b96c182)
- Removed duplicated architecture from operator manual
- References `docs/design/` for architecture, `src/` for schemas
- Keeps only operator concerns: startup, monitoring, intervention, commands, intercom

## Test plan

- [x] All 71 tests pass
- [x] Build succeeds after nanoclaw cleanup
- [x] Pre-push hook passes (type-check + tests)
- [x] Pre-commit README sibling rule works (caught missing docs/design/README.md update)
- [ ] Verify no runtime references to deleted nanoclaw files
- [ ] Review `external/README.md` fork strategy
- [ ] Review slimmed operator/CLAUDE.md in secrets repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)