### PR TITLE
docs: define chain of command — CO/XO/Chief

### DIFF
--- a/docs/design/05-bot.md
+++ b/docs/design/05-bot.md
@@ -48,7 +48,7 @@ Controls when the bot responds to messages:
 | Value | Behavior |
 |-------|----------|
 | `always` | Every message triggers a response (no callout needed) |
-| `callout` | Requires explicit `<m>name</m>` mention, participating thread, or CO main timeline |
+| `callout` | Requires explicit `<m>name</m>` mention, participating thread, or Chief fallback on main timeline |
 | `never` | Bot is stopped — no responses |
 
 The relay sets `triggerType` on status transitions:
@@ -127,7 +127,7 @@ When `triggerType` is `callout`, three conditions can trigger a response:
 |-----------|-------------|
 | **Callout** | Message contains `<m>name</m>` (the trigger pattern) |
 | **Participating thread** | Message is in a thread where the bot previously responded |
-| **CO main timeline** | Bot is CO and message doesn't mention any known bot (checked via `\b<name>\b` word-boundary against roster) |
+| **Chief fallback** | Bot is Chief (lowest-rank-number active in room) and message doesn't mention any known bot (checked via `\b<name>\b` word-boundary against roster) |
 
 When `triggerType` is `always`, every message triggers a response — no conditions needed.
 
@@ -170,9 +170,9 @@ The pip reflects **operational status**, not which room the bot is in. See [09-r
 | 🚀 | Starting — transient boot stage |
 | 🟡 | Waiting — transient boot stage |
 | 🟢 | Online — running, responding |
-| ⭐ | CO — commanding officer |
+| ⭐ | Chief — room lead (lowest-rank-number active bot in duty room) |
 
-> **Status:** Dynamic pip transitions (🔄 → 🚀 → 🟡 → 🟢) during boot are not yet implemented. `setStatusPip()` is currently a no-op in `channels/matrix.ts`. The relay sets pips at lifecycle boundaries (💤 on sleep, 🟢 on wake completion, ⭐ on CO) but not during boot stages. See [#27](https://github.com/wawiesel/InfiniClaw/issues/27).
+> **Status:** Dynamic pip transitions (🔄 → 🚀 → 🟡 → 🟢) during boot are not yet implemented. `setStatusPip()` is currently a no-op in `channels/matrix.ts`. The relay sets pips at lifecycle boundaries (💤 on sleep, 🟢 on wake completion, ⭐ on Chief) but not during boot stages. See [#27](https://github.com/wawiesel/InfiniClaw/issues/27).
 
 ### Boot Progress Messages
 

--- a/docs/design/09-roles-and-rooms.md
+++ b/docs/design/09-roles-and-rooms.md
@@ -45,7 +45,7 @@ A bot in its quarters room is a **primary** — it owns the room. Trigger behavi
 | Status | triggerType | Responds to |
 |--------|------------|-------------|
 | `quarters` (awake) | `always` | Anyone — every message triggers |
-| `onduty` | `callout` | Explicit `<m>Name</m>`, participating thread, or CO |
+| `onduty` | `callout` | Explicit `<m>Name</m>`, participating thread, or Chief fallback |
 | `sleep` | `never` | Nothing — but captain/operator mentions auto-wake |
 
 When a sleeping bot receives a captain/operator mention, the relay auto-wakes it (transitions `sleep` → `quarters`, `triggerType` → `always`), delivers the message, then the bot stays awake until explicitly put back to sleep.
@@ -93,9 +93,9 @@ The pip reflects **operational status**, not which room the bot is in. A bot's r
 | 🚀 | starting | Transient — container spawning |
 | 🟡 | waiting | Transient — waiting for first output |
 | 🟢 | online | Running, responding |
-| ⭐ | CO | Commanding officer (special online) |
+| ⭐ | Chief | Room lead — highest-rank active bot in duty room |
 
-Display name format: `<pip> <name> <shipEmoji>` (e.g. `🟢 Cid 🦁`). CO is elected automatically — lowest-rank active bot in a duty room.
+Display name format: `<pip> <name> <shipEmoji>` (e.g. `🟢 Cid 🦁`). Chief is elected automatically — lowest-rank-number active bot in a duty room (see [12-co](12-co.md)).
 
 ### Room assignment
 
@@ -253,7 +253,7 @@ Ship space IDs in `ships.json`:
 3. **triggerType on dismiss** — Dismissed bot switches to `always` trigger.
    *Check:* fleet.json shows `triggerType: "always"` after dismiss. Brain model unchanged.
 
-4. **CO election** — Two bots in Engineering, lowest rank gets ⭐.
+4. **Chief election** — Two bots in Engineering, lowest rank number gets ⭐.
    *Check:* Lower-ranked bot's display name shows ⭐. Higher-ranked shows 🟢.
 
 5. **Bot room memory** — Bot posts a learning to its quarters room.

--- a/docs/design/12-co.md
+++ b/docs/design/12-co.md
@@ -1,47 +1,67 @@
-# 12 — Commanding Officer
+# 12 — Chain of Command
 
-> **CO vs Chief:** These are two distinct roles. The **CO** (⭐, lowest rank) handles message fielding and responsiveness. The **Chief** (highest rank) leads the room strategically — sets direction and delegates to crew. See [09-roles-and-rooms](09-roles-and-rooms.md) for the full command hierarchy.
+## Rank Structure
 
-Each room has a **Commanding Officer (CO)** — the lowest-rank active bot in that room. The CO acts as the primary orchestrator, triage agent, and reviewer for the room.
+| Title | Who | Scope |
+|-------|-----|-------|
+| **CO** (Commanding Officers) | Captain + Operator | Fleet-wide authority |
+| **XO** (Executive Officer) | Chief Navigator (highest-rank navigator on bridge) | Fleet coordination, second in command |
+| **Chief** | Highest-rank active bot per duty room | Room lead — triage, delegation, review |
 
-## The Manager Role
+"Highest rank" = lowest rank number (rank 1 outranks rank 2).
 
-In the **Branch and Merge** architecture, the CO's Main Brain acts as a manager:
+## Chain of Command
+
+```
+Captain → Operator → Chief (per room) → other bots
+```
+
+The Captain sets direction. The Operator executes fleet management and relays orders. Each duty room's Chief leads the bots in that room — triaging messages, delegating work, and reviewing output.
+
+The Chief Navigator is special: they serve as **XO**, coordinating across the fleet from the bridge. All other Chiefs are scoped to their duty room (Chief Engineer in Engineering, Chief Architect in Astrometrics).
+
+## The Chief Role
+
+Each duty room has a **Chief** — the lowest-rank-number active bot in that room. The Chief acts as the primary orchestrator, triage agent, and reviewer for the room.
+
+### The Manager Role
+
+In the **Branch and Merge** architecture, the Chief's Main Brain acts as a manager:
 1.  **Fielding:** It responds instantly (within 2 seconds) to unaddressed messages on the main timeline.
-2.  **Branching:** If a request requires significant work, the CO uses the `branch_to_thread` tool to create a task-specific Branch Brain.
-3.  **Delegation:** In the thread, the CO pings other bots (e.g., `@Cid`) to perform the work.
-4.  **Reviewing:** The CO's Branch Brain interacts with the non-CO bot in the thread, reviewing findings and approving code changes.
-5.  **Merging:** Once approved, the CO merges the task outcome into `MEMORY.md` and posts a final summary to the Captain on the main timeline.
+2.  **Branching:** If a request requires significant work, the Chief uses the `branch_to_thread` tool to create a task-specific Branch Brain.
+3.  **Delegation:** In the thread, the Chief pings other bots (e.g., `@Cid`) to perform the work.
+4.  **Reviewing:** The Chief's Branch Brain interacts with the non-Chief bot in the thread, reviewing findings and approving code changes.
+5.  **Merging:** Once approved, the Chief merges the task outcome into `MEMORY.md` and posts a final summary to the Captain on the main timeline.
 
-## CO Election
+## Chief Election
 
-CO is determined from `fleet.json` at startup and updated at runtime via relay lifecycle messages.
+Chief is determined from `fleet.json` at startup and updated at runtime via relay lifecycle messages.
 
 ### Startup
-Each bot reads the `IS_CO` environment variable (injected by the host based on `fleet.json`) to set its initial badge. Display name badges: ⭐ = CO, 🟢 = active.
+Each bot reads the `IS_CO` environment variable (injected by the host based on `fleet.json`) to set its initial badge. Display name badges: ⭐ = Chief, 🟢 = active.
 
 ### Runtime Updates
-When the relay dismisses or joins a bot, it posts a lifecycle message via intercom (e.g., `HERACLES: Cid stopped`). All bots parse these messages to update their in-memory `roomRoster` and re-evaluate who holds the CO role.
+When the relay dismisses or joins a bot, it posts a lifecycle message via intercom (e.g., `HERACLES: Cid stopped`). All bots parse these messages to update their in-memory `roomRoster` and re-evaluate who holds the Chief role.
 
-> **Status:** Implemented. Relay broadcasts lifecycle messages after dismiss, sleep, report, and promote/demote via the bot's duty room intercom connection. Bots update `roomRoster` and re-evaluate CO on receipt.
+> **Status:** Implemented. Relay broadcasts lifecycle messages after dismiss, sleep, report, and promote/demote via the bot's duty room intercom connection. Bots update `roomRoster` and re-evaluate Chief on receipt.
 
 ## Responsiveness
 
-The CO's Main Brain is **non-blocking**. It never performs heavy tasks. If only the CO is available, it still branches to a Branch Brain to do the work, ensuring the Main Brain is always ready to field the next message from the Captain.
+The Chief's Main Brain is **non-blocking**. It never performs heavy tasks. If only the Chief is available, it still branches to a Branch Brain to do the work, ensuring the Main Brain is always ready to field the next message from the Captain.
 
 ## Verification
 
-1. **CO elected** — Two bots in the same room, lowest rank gets CO.
+1. **Chief elected** — Two bots in the same room, lowest rank number gets Chief.
    *Check:* Lower-ranked bot has ⭐ pip. Higher-ranked has 🟢.
 
-2. **CO responds to unaddressed messages** — Post a message without mentioning any bot.
-   *Check:* CO responds. Non-CO bots stay silent.
+2. **Chief responds to unaddressed messages** — Post a message without mentioning any bot.
+   *Check:* Chief responds. Non-Chief bots stay silent.
 
-3. **CO delegates** — CO receives a complex request.
-   *Check:* CO branches to thread, tags another bot for the work.
+3. **Chief delegates** — Chief receives a complex request.
+   *Check:* Chief branches to thread, tags another bot for the work.
 
-4. **CO re-election** — Dismiss the current CO.
+4. **Chief re-election** — Dismiss the current Chief.
    *Check:* Next-lowest-rank bot gets ⭐. Display name updates.
 
-5. **CO non-blocking** — Send rapid messages while CO has an active thread.
-   *Check:* CO's Main Brain responds immediately on main timeline.
+5. **Chief non-blocking** — Send rapid messages while Chief has an active thread.
+   *Check:* Chief's Main Brain responds immediately on main timeline.

--- a/docs/design/18-deployment.md
+++ b/docs/design/18-deployment.md
@@ -51,7 +51,7 @@ This is the core gate. A fully self-contained InfiniClaw instance runs inside a 
 The real bot who developed the changes acts as Captain and Operator of the simulated ship. They run the crew through scenarios that exercise the changed code paths. At minimum:
 
 - Bot startup and Matrix connection
-- Message routing (direct mention, thread participation, CO duty)
+- Message routing (direct mention, thread participation, Chief fallback)
 - IPC commands (restart, health check, fleet status)
 - Any feature-specific scenarios relevant to the branch
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,7 +22,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 - `09-roles-and-rooms.md` — Roles, room topology, command hierarchy (Captain → Operator/Co → XO → Chiefs → Crew; Chief = highest-rank bot per room; Chief Navigator = XO), bot statuses (pip progression), lifecycle commands (!wake/!sleep/!report/!dismiss/!go), quarters trigger rules, quarters as retrospective memory space
 - `10-fleet.md` — fleet.json, transport protocol, S3 coordination, fleet metrics (availability, autonomy score)
 - `11-commands.md` — X-commands (`!`-prefixed fleet control), room-scoped targeting (presence-based for most commands, assignment-based for !report, universal from BTC), `!pull [ship]` (no arg = all ships) / `!push [ship]` commands, `!operator` toggle, `!metrics` (context-aware, 1d/7d rolling), status formats, alert threads. `!rejoin` and `!refresh` removed — `!wake` handles both restart and wake.
-- `12-co.md` — Commanding Officer (CO = lowest rank, handles fielding) vs Chief (highest rank, room lead); CO election and delegation
+- `12-co.md` — Chain of command (CO/XO/Chief), Chief election and delegation
 - `13-intercom.md` — Intercom accounts (bridge/engineering/astrometrics), loudspeaker replies (`[emoji Ship]` prefix), `@loudspeaker:` bot broadcast (implemented), `@room:` targeted routing (not yet implemented)
 
 ## Resilience


### PR DESCRIPTION
## Summary
- Captain clarified fleet rank structure: CO = Captain+Operator, XO = Chief Navigator (bridge), Chief = room lead per duty room
- Renamed "CO" to "Chief" in design docs 05, 09, 12, 18 for bot room leaders
- Added chain of command section to 12-co.md: Captain → Operator → Chief → other bots
- Code still uses `isCO`/`isCommandingOfficer` — variable rename is a separate code PR

## Test plan
- [x] All 181 tests pass
- [ ] Review terminology consistency across all design docs
- [ ] Verify no code changes needed (doc-only PR)