### PR TITLE
docs: 03-container.md review pass — fix credential proxy claim

### DIFF
--- a/docs/design/03-container.md
+++ b/docs/design/03-container.md
@@ -50,7 +50,7 @@ Two-tier design: read-only everywhere, write access where needed.
 
 - **No credentials in git.** Bot env files live in the secrets repo (`~/.config/infiniclaw/secrets/`). `.mcp.json` files (may contain OAuth tokens) are gitignored.
 - **Secrets flow:** Profile env files → loaded by host process → written to a mounted env file at `/workspace/env-dir/env` (read-only inside container). The entrypoint sources this file. `CONTAINER_ENV_*` vars are injected separately as `-e` flags with the prefix stripped.
-- **Credential proxy:** Containers never see real API keys. `ANTHROPIC_BASE_URL` points to a host-side proxy that injects credentials per-request.
+- **Credential allowlist:** Only a fixed set of permitted keys are written to the container env file — `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_MODEL`, and a small set of other required keys. All other host env vars are excluded. See [#37](https://github.com/wawiesel/InfiniClaw/issues/37).
 - **Mount allowlist** is stored outside the repo (`~/.config/infiniclaw/allow-list.json`) so containers can't tamper with it.
 - **Cert mapping:** Host CA cert paths are mapped to container-compatible locations for Node, Python, curl, and git (`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`).
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,7 +7,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 - `00-overview.md` — Definitions (fleet, ship, relay, bot, operator, space, room, duty room), core principles, code structure
 - `01-operator.md` — Operator as escape hatch (host-side tmux, max intelligence, idle in mature fleet), bootstrap foundations (Matrix + S3 + secrets → BehindTheCurtain → first ship → first bot), accounts, Captain communication (all ships with operatorRelay=true receive BTC; !operator on/off per ship), inter-operator inbox, x-commands, operating modes (📡 Watch/👑 Captain/🔧 Fix with mode icon in message prefix), autonomy metrics (interventions/day, 1d/7d rolling)
 - `02-matrix.md` — Matrix server, accounts, room naming convention (double-emoji on all rooms and spaces), ship spaces (example not prescriptive), room setup (m.space.child + m.space.parent both required), message format, `<m>` mention pills, reactions (📡/👀/🔔 status pipeline, 👍️/👎️/💯/❌️ scoring), special mentions (@operator, @loudspeaker broadcast/fleet-status, @room intercom), bot Matrix navigation tools, verification
-- `03-container.md` — Persistent Podman containers (one per bot, not per turn), internal concurrency (agent runner + persistent main brain + lobes), branch brains on host, image builds, mount table (corrected runtime paths), secrets flow
+- `03-container.md` — Persistent Podman containers (one per bot, not per turn), internal concurrency (agent runner + persistent main brain + lobes), branch brains on host, image builds, mount table (corrected runtime paths), secrets flow (credential allowlist, not proxy — #37)
 
 ## Bot Runtime
 


### PR DESCRIPTION
## Summary
- Fixes inaccurate claim that containers never see real API keys (credential proxy is aspirational, not implemented)
- Part of design doc review cycle (issue #33)

## Test plan
- [x] Doc accuracy verified against code