### PR TITLE
fix(group-queue): yield freed slot to waiting groups (BUG-26)

### DIFF
--- a/external/nanoclaw/src/README.md
+++ b/external/nanoclaw/src/README.md
@@ -11,7 +11,7 @@ Clean fork of [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw). Platfor
 | `types.ts` | Core interfaces: `Channel`, `NewMessage`, `RegisteredGroup` |
 | `router.ts` | `formatMessages` (XML → bot prompt), `findChannel` |
 | `db.ts` | SQLite message/chat/group store |
-| `group-queue.ts` | Per-group container queue — serializes agent runs, IPC piping |
+| `group-queue.ts` | Per-group container queue — serializes agent runs, IPC piping, fair slot scheduling |
 | `container-runner.ts` | Spawns podman containers for agent runs |
 | `container-runtime.ts` | Container runtime detection |
 | `credential-proxy.ts` | Credential proxy for secure secret injection |

--- a/external/nanoclaw/src/group-queue.test.ts
+++ b/external/nanoclaw/src/group-queue.test.ts
@@ -433,6 +433,41 @@ describe('GroupQueue', () => {
     await vi.advanceTimersByTimeAsync(10);
   });
 
+  // --- BUG-26: starvation fix ---
+
+  it('yields freed slot to waiting groups instead of self-re-running (BUG-26)', async () => {
+    const processed: string[] = [];
+    const completionCallbacks: Array<() => void> = [];
+
+    const processMessages = vi.fn(async (groupJid: string) => {
+      processed.push(groupJid);
+      await new Promise<void>((resolve) => completionCallbacks.push(resolve));
+      return true;
+    });
+
+    queue.setProcessMessagesFn(processMessages);
+
+    // Fill both slots with group1 and group2
+    queue.enqueueMessageCheck('group1@g.us');
+    queue.enqueueMessageCheck('group2@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+
+    // group3 waits for a slot
+    queue.enqueueMessageCheck('group3@g.us');
+    await vi.advanceTimersByTimeAsync(10);
+
+    // group1 gets a new message while running — it will have pendingMessages on finish
+    queue.enqueueMessageCheck('group1@g.us');
+
+    // group1 finishes — should yield slot to group3 (waiting), not re-run itself
+    completionCallbacks[0]();
+    await vi.advanceTimersByTimeAsync(10);
+
+    // group3 must have gotten the slot, not group1's re-run
+    const thirdRun = processed[2];
+    expect(thirdRun).toBe('group3@g.us');
+  });
+
   it('preempts when idle arrives with pending tasks', async () => {
     const fs = await import('fs');
     let resolveProcess: () => void;

--- a/external/nanoclaw/src/group-queue.ts
+++ b/external/nanoclaw/src/group-queue.ts
@@ -287,7 +287,20 @@ export class GroupQueue {
     if (this.shuttingDown) return;
 
     const state = this.getGroup(groupJid);
+    const hasPending =
+      state.pendingTasks.length > 0 || state.pendingMessages;
 
+    // If other groups are waiting, yield the freed slot to them first.
+    // Re-enqueue this group at the back so it gets a fair turn.
+    if (hasPending && this.waitingGroups.length > 0) {
+      if (!this.waitingGroups.includes(groupJid)) {
+        this.waitingGroups.push(groupJid);
+      }
+      this.drainWaiting();
+      return;
+    }
+
+    // No waiting groups — serve this group immediately.
     // Tasks first (they won't be re-discovered from SQLite like messages)
     if (state.pendingTasks.length > 0) {
       const task = state.pendingTasks.shift()!;
@@ -300,7 +313,6 @@ export class GroupQueue {
       return;
     }
 
-    // Then pending messages
     if (state.pendingMessages) {
       this.runForGroup(groupJid, 'drain').catch((err) =>
         logger.error(


### PR DESCRIPTION
## Summary
- **Root cause:** `drainGroup()` immediately re-consumed the freed slot for the finishing group even when other groups were waiting in `waitingGroups`. A high-traffic group could hold the concurrency ceiling indefinitely, starving all waiting groups.
- **Fix:** When `waitingGroups` is non-empty and the finishing group has pending work, push it to the back of the wait queue and call `drainWaiting()` — giving waiting groups fair access to the freed slot.
- **Test:** Adds regression test `yields freed slot to waiting groups instead of self-re-running (BUG-26)` — all 14 GroupQueue tests pass.

## Design reference
Closes #17 (BUG-26)

## Test plan
- [x] Built successfully (`npm run build`)
- [x] 14/14 GroupQueue tests pass (`npx vitest run` in `external/nanoclaw/`)
- [x] Existing starvation/fairness covered by new regression test