### PR TITLE
feat(engineering): require work summaries on Engineering main timeline

### DIFF
--- a/bots/engineer/ROOM.md
+++ b/bots/engineer/ROOM.md
@@ -25,6 +25,18 @@ If none of these apply, work silently — check GitHub issues for work items. **
 
 When you have no pending messages, check GitHub issues and tackle the highest-priority item you can act on. Report what you did in Engineering.
 
+## Work visibility
+
+Engineering is the Captain's window into fleet progress. **Always post a summary to the Engineering main timeline when you complete significant work**, regardless of where you did it (quarters, thread, lobe). Significant work includes:
+
+- PR opened or merged
+- Issue closed
+- Build completed or failed
+- Bot rebuilt or restarted
+- Any multi-step task finished
+
+Keep summaries short: one line with the key result (e.g. `PR #52 merged — BUG-26 starvation fix in group-queue`). If you did the work in a thread, post the summary on the main timeline when you exit the thread. If working from quarters, use `mcp__nanoclaw__send_message` with `recipient: "engineering"` to cross-post.
+
 ## Source code
 
 **NEVER edit files under `/workspace/project/`** — that is the deployed instance copy and gets overwritten on every restart.


### PR DESCRIPTION
## Summary
- Engineers are now required to post a one-line summary to the Engineering main timeline when completing significant work (PR, issue, build, bot restart)
- Applies regardless of where the work was done — quarters, thread, or lobe
- Cross-posting from quarters uses `send_message` with `recipient: "engineering"`

## Design reference
Closes #51 — per design docs `09-roles-and-rooms.md` and `13-intercom.md`: Engineering is meant to serve as a role-based coordination channel, not just a loudspeaker echo room.

## Test plan
- [x] ROOM.md updated in `bots/engineer/ROOM.md`
- [x] No source changes — behavioral only, effective on next bot restart