### PR TITLE
feat(semver): version-gate !pull restarts on semver tag advancement

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -69,7 +69,7 @@ Host machine (macOS / Linux)
 ├── formatting.ts       → Message formatting helpers: capitalizeName, escapeHtml, statusMessage, formatBotDisplayName, PIP_FOR_STATUS, ROLE_ICONS, rankMedal, botBadge, isBotCO, shipHeaderLine, botTreeLine, unifiedBotDisplay (short/medium/long verbosity)
 ├── git-utils.ts        → Shared git helpers: gitOpts(), execErrOutput(), gitSyncRepo() (stash→rebase→pop, conflict hard-reset)
 ├── utils.ts            → Shared utilities: isRecord, sleep, shellQuote, errStr, envInt, escapeRegex, readJson, writeJson
-└── version.ts          → Git version resolution (prefers stamped GIT_VERSION file)
+└── version.ts          → Git version resolution (prefers stamped GIT_VERSION file); `getLatestSemverTag()`/`getStampedSemverTag()` for semver deploy gating
 ```
 
 ## NanoClaw as a library

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -83,6 +83,7 @@ import {
   syncDistToInstance,
   collectBotMatrixUserMap,
 } from './service.js';
+import { getLatestSemverTag, getStampedSemverTag } from './version.js';
 import { sleep, shellQuote, errStr, envInt, escapeRegex } from './utils.js';
 import { gitOpts, execErrOutput, gitSyncRepo } from './git-utils.js';
 import { readWbs, writeWbs, itemsForBot, reabsorbItems, autoAssign, completeItem } from './wbs.js';
@@ -2812,7 +2813,9 @@ function registerRelayCommands(): void {
     },
 
     pull: async (cmd, conn) => {
-      const targetShip = cmd.slice('!pull'.length).trim() || null;
+      const args = cmd.slice('!pull'.length).trim();
+      const force = args === '--force' || args.startsWith('--force ');
+      const targetShip = (force ? args.slice('--force'.length) : args).trim() || null;
       if (targetShip && !isThisShip(targetShip)) return;
       const startedAt = Date.now();
 
@@ -2876,6 +2879,25 @@ function registerRelayCommands(): void {
           }
         }
 
+        // Semver version gate: skip restarts if the deployed tag matches the latest tag,
+        // unless --force was passed. With no semver tags yet, always restart.
+        const relayDir = path.join(root, '_runtime', 'relay');
+        const latestTag = getLatestSemverTag(root);
+        const deployedTag = getStampedSemverTag(relayDir);
+        const tagAdvanced = !latestTag || !deployedTag || latestTag !== deployedTag;
+        if (!force && !tagAdvanced) {
+          await s(stageOk(`version gate: ${latestTag} already deployed — skipping restarts (use !pull --force to override)`));
+          persistFleet();
+          await publishFleetReport().catch(() => {});
+          const msg = pullResult('complete (no new version)', warnings, errors, elapsed());
+          await s(msg);
+          await reply(conn, msg);
+          return;
+        }
+        if (latestTag) {
+          await s(stageOk(`version gate: advancing to ${latestTag}${force ? ' (forced)' : ''}`));
+        }
+
         if (isShipCommissioned()) {
           ensurePodmanReady();
           removeStaleProcesses();
@@ -2901,6 +2923,14 @@ function registerRelayCommands(): void {
           }
         } else {
           await s(stageOk('ship decommissioned — skipping bot startup'));
+        }
+
+        // Stamp deployed semver tag so next !pull can compare
+        if (latestTag) {
+          try {
+            fs.mkdirSync(relayDir, { recursive: true });
+            fs.writeFileSync(path.join(relayDir, 'SEMVER_VERSION'), `${latestTag}\n`);
+          } catch { /* best effort */ }
         }
 
         persistFleet();

--- a/src/service.ts
+++ b/src/service.ts
@@ -437,6 +437,23 @@ export function stampGitVersion(root: string, instance: string): void {
   } catch {
     // Not a git repo or git unavailable — skip
   }
+  stampSemverVersion(root, instance);
+}
+
+/**
+ * Stamp the latest semver tag into SEMVER_VERSION so !pull can compare
+ * deployed tag vs latest without a live git query inside the container.
+ */
+export function stampSemverVersion(root: string, instance: string): void {
+  try {
+    const tag = execSync('git describe --tags --match "v*.*.*" --abbrev=0', {
+      cwd: root, encoding: 'utf-8' as const, stdio: 'pipe' as const,
+    }).trim();
+    fs.writeFileSync(path.join(instance, 'SEMVER_VERSION'), `${tag}\n`);
+  } catch {
+    // No semver tag yet — write empty marker so callers get null cleanly
+    try { fs.writeFileSync(path.join(instance, 'SEMVER_VERSION'), ''); } catch { /* ok */ }
+  }
 }
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -20,3 +20,31 @@ export const GIT_VERSION = (() => {
     return 'unknown';
   }
 })();
+
+/**
+ * Get the latest semver git tag (`v*.*.*`) reachable from HEAD in the given repo.
+ * Returns null if no semver tag exists.
+ */
+export function getLatestSemverTag(cwd: string): string | null {
+  try {
+    const tag = execSync('git describe --tags --match "v*.*.*" --abbrev=0', {
+      cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return tag || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the semver tag stamped at deploy time from a SEMVER_VERSION file.
+ * Written by stampSemverVersion() in service.ts. Returns null if not stamped.
+ */
+export function getStampedSemverTag(instanceDir: string): string | null {
+  try {
+    const tag = fs.readFileSync(path.join(instanceDir, 'SEMVER_VERSION'), 'utf-8').trim();
+    return tag || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- `!pull` now checks the deployed semver tag vs the latest `v*.*.*` git tag before restarting bots
- If tag hasn't advanced, skips the restart phase entirely (code/secrets still synced)
- `!pull --force` bypasses the version gate and always restarts
- `stampGitVersion()` now also stamps `SEMVER_VERSION` alongside `GIT_VERSION` on every deploy
- Relay stamps `_runtime/relay/SEMVER_VERSION` after each successful pull for comparison next run
- When no semver tags exist yet, behavior is unchanged (always restart)

## Design reference
Closes #5 — semantic versioning for relay/bot deployments

## Test plan
- [x] Built successfully (`npm run build`)
- [x] No test regressions (`npx vitest run` — same pre-existing failures as before)
- [x] Backward compatible: no semver tags = always restart (existing behavior)