### PR TITLE
docs: fix 09-roles-and-rooms.md for duty cycle statuses

### DIFF
--- a/docs/design/09-roles-and-rooms.md
+++ b/docs/design/09-roles-and-rooms.md
@@ -89,6 +89,9 @@ The pip reflects **operational status**, not which room the bot is in. A bot's r
 | Pip | Status | Meaning |
 |-----|--------|---------|
 | 💤 | sleep | Container stopped |
+| 📝 | retrospective | Dismissed to quarters; reflecting on duty cycle |
+| 💤 | dream | Container stopped; deferred code changes applying |
+| ✅ | ready | Container started fresh; awaiting next `!report` |
 | 🔄 | building | Transient — container image building |
 | 🚀 | starting | Transient — container spawning |
 | 🟡 | waiting | Transient — waiting for first output |
@@ -105,7 +108,10 @@ A bot is **always** in its quarters room. It can be in at most one additional ro
 |-------------------|-------|-------|-------------|-----------|
 | `onduty` | Quarters + duty room | Full model | `callout` | Running |
 | `quarters` | Quarters only | Full model | `always` | Running |
+| `retrospective` | Quarters only | Full model | `always` | Running |
 | `sleep` | Quarters only | — | `never` | Stopped |
+| `dream` | Quarters only | — | `never` | Stopped |
+| `ready` | Quarters only | Full model | `always` | Running |
 | `transit` | — | — | `never` | Stopped |
 
 Quarters and onduty are functionally identical environments — same brain, same lobes, same branch brains. The only differences are which rooms the bot is in and `triggerType`. A bot in quarters is transferrable to another ship without reboot.
@@ -209,7 +215,7 @@ quarters → report → ON DUTY → dismiss → quarters → retrospective → s
 
 ### No Resync While On Duty
 
-**Critical rule:** The git sync loop must NOT restart a bot that is on duty. Code changes detected during a duty cycle are **queued** and applied during the Dream phase. Only an emergency override (`!wake --force`) can interrupt an active duty cycle.
+**Critical rule:** The git sync loop must NOT restart a bot that is on duty. Code changes detected during a duty cycle are **queued** and applied during the Dream phase. To interrupt a duty cycle, use `!dismiss` then `!sleep` manually.
 
 Change classification:
 - **Runtime** (`src/*.ts`, `package.json`, `Dockerfile`): queued until Dream phase
@@ -218,7 +224,7 @@ Change classification:
 
 ### Duty Timer
 
-`ondutyAt` is tracked per bot in `_runtime/data/ipc/{bot}/status.json`. On each branch brain completion or heartbeat, the relay checks if `DUTY_CYCLE_MS` has elapsed.
+`ondutyAt` is tracked per bot in `fleet.json` (set by `fleetUpdate` on `!report`, cleared on `!dismiss`). The `dutyCycleLoop` checks every 60s whether any onduty bot has exceeded `DUTY_CYCLE_MS`.
 
 ### Retrospective Sequence
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -19,7 +19,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 
 ## Organization
 
-- `09-roles-and-rooms.md` — Roles, room topology, command hierarchy (Captain → Operator/Co → XO → Chiefs → Crew; Chief = highest-rank bot per room; Chief Navigator = XO), bot statuses (pip progression), lifecycle commands (!wake/!sleep/!report/!dismiss/!go), quarters trigger rules, quarters as retrospective memory space, duty cycle (quarters→onduty→retrospective→sleep→dream→ready, no resync while on duty)
+- `09-roles-and-rooms.md` — Roles, room topology, command hierarchy (Captain → Operator/Co → XO → Chiefs → Crew; Chief = highest-rank bot per room; Chief Navigator = XO), bot statuses (pip progression: 🟢/📝/💤/✅ for onduty/retrospective/dream/ready), lifecycle commands (!wake/!sleep/!report/!dismiss/!go), quarters trigger rules, quarters as retrospective memory space, duty cycle (quarters→onduty→retrospective→sleep→dream→ready, ondutyAt in fleet.json, no resync while on duty)
 - `10-fleet.md` — fleet.json, transport protocol, S3 coordination, fleet metrics (availability, autonomy score)
 - `11-commands.md` — X-commands (`!`-prefixed fleet control), room-scoped targeting (presence-based for most commands, assignment-based for !report, universal from BTC), `!pull [ship]` (no arg = all ships) / `!push [ship]` commands, `!operator` toggle, `!metrics` (context-aware, 1d/7d rolling), status formats, alert threads. `!rejoin` and `!refresh` removed — `!wake` handles both restart and wake.
 - `12-co.md` — Chain of command (CO/XO/Chief), Chief election and delegation, Work Breakdown Structure (WBS) — per-room task list with dependencies, auto-assignment on bot startup, reabsorption on off-duty


### PR DESCRIPTION
## Summary
- Add `retrospective` (📝) / `dream` (💤) / `ready` (✅) to the pip status table — missing after PRs #62/#63
- Add those 3 statuses to the room assignment table with correct rooms/triggerType/container state
- Fix `ondutyAt` location: doc said `_runtime/data/ipc/{bot}/status.json`, code uses `fleet.json`
- Remove `!wake --force` (does not exist — only `!pull --force` is implemented; use `!dismiss` + `!sleep` to manually interrupt)
- Update README.md index

## Design reference
[09-roles-and-rooms.md](docs/design/09-roles-and-rooms.md)