### PR TITLE
docs: add fleet availability to 20-metrics.md Reliability table

### DIFF
--- a/docs/design/20-metrics.md
+++ b/docs/design/20-metrics.md
@@ -46,12 +46,15 @@ Five categories. A mature fleet scores well on all five. A fleet in crisis will 
 
 | Metric | Formula | Good | Alarm | Status |
 |--------|---------|------|-------|--------|
+| **Fleet availability** | % of non-sleeping bots with running processes (snapshot) | 100% | < 80% | ✅ Tracked |
 | **Relay uptime %** | % of last 24h relay was running (approx: current uptime / 86400s) | 100% (1d) | < 90% | ✅ Tracked (approx) |
 | **Response latency** | p50/p95 time from Captain mention to first bot reply | < 30s p50 | > 2min p95 | ✅ Tracked |
 | **Crashes/day** | PM2 restart count per day | 0 | > 2/day | ✅ Tracked |
 | **OOM kills/day** | Container killed by memory limit per day | 0 | Any | ✅ Tracked |
 | **SIGKILL/day** | Forced process termination per day | 0 | > 0 | ✅ Tracked |
 | **RSS / limit** | Current RSS vs container memory cap (snapshot) | < 80% | > 90% | ✅ Tracked |
+
+**Fleet availability** = `running / (total − sleeping − transit) × 100`. A bot in `quarters`, `onduty`, `retrospective`, or `ready` is "assigned" and counts in the denominator. Displayed as `avail XX%` in `!metrics` footer. 100% = all assigned bots have running processes.
 
 **Relay uptime %** is approximated as `min(uptimeSeconds, 86400) / 86400 × 100`. If the relay has been continuously running for 22h, that's 92%. If it just restarted, it's near 0%. Displayed as `up 91% (1d)` in `!metrics`. This understates reliability if the relay restarts quickly, but a low % always means something went wrong recently. The precise implementation (recording stop/start timestamps) is planned — see below.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -36,7 +36,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 - `17-skills.md` — Pooled capability modules per role
 - `18-deployment.md` — Code pipeline, holodeck simulation gates
 - `19-infrastructure.md` — Ships as VMs, Gitea/MinIO redundancy
-- `20-metrics.md` — Full metrics taxonomy: Productivity (messages/day, token throughput, score, task completion), Reliability (uptime %, response latency, crashes, OOM, RSS), Autonomy (interventions, autonomy score, MTBI), Infrastructure (relay restarts, sync failures, fleet RSS). Marks ✅ tracked vs 🔲 planned. Token throughput, response latency, and MTBI now ✅ implemented. Messages/day corrected to 🔲 planned. Uptime as rolling % (not duration). All rolling 1d/7d — no cumulative totals.
+- `20-metrics.md` — Full metrics taxonomy: Productivity (messages/day, token throughput, score, task completion), Reliability (fleet availability ✅, uptime %, response latency, crashes, OOM, RSS), Autonomy (interventions, autonomy score, MTBI), Infrastructure (relay restarts, sync failures, fleet RSS). Marks ✅ tracked vs 🔲 planned. Token throughput, response latency, MTBI, fleet availability now ✅ implemented. Messages/day still 🔲 planned. All rolling 1d/7d — no cumulative totals.
 
 Engineers cannot modify these files (enforced by pre-commit hook). Architecture changes go through the Architect role.
 


### PR DESCRIPTION
## Summary
- All ✅/🔲 markers in 20-metrics.md match the code — no marker corrections needed
- Found one gap: `FleetMetrics.availability` is computed in `metrics.ts` (`computeFleetMetrics`) and shown in `!metrics` output but was missing from the Reliability table
- Added **Fleet availability** row (✅ Tracked): `running / assigned × 100`, snapshot, shown as `avail XX%` in metrics footer
- Updated README.md index

## Design reference
[20-metrics.md](docs/design/20-metrics.md)