### PR TITLE
docs: fix 10-fleet.md transport status and expand fleet.json schema

### DIFF
--- a/docs/design/10-fleet.md
+++ b/docs/design/10-fleet.md
@@ -15,7 +15,16 @@ Fleet-wide bot availability is tracked in `fleet.json` and synced via git. The r
     "architect": { "rw": ["infiniclaw", "aegis"] }
   },
   "bots": {
-    "cid": { "role": "engineer", "rank": 2, "ship": "HERACLES", "status": "onduty" }
+    "cid": {
+      "role": "engineer",
+      "rank": 2,
+      "ship": "HERACLES",
+      "status": "onduty",
+      "triggerType": "callout",
+      "quartersRoom": "!roomId:homeserver",
+      "activeBrainModel": "claude-sonnet-4-6",
+      "ondutyAt": 1710000000000
+    }
   }
 }
 ```
@@ -25,7 +34,7 @@ Fleet-wide bot availability is tracked in `fleet.json` and synced via git. The r
 `!transport <bot> <ship>` moves a bot between ships via a two-phase git protocol:
 
 1. **Dematerialize** — source ship stops the bot, writes `ship: targetShip, status: "transit"` to fleet.json, and pushes.
-2. **Materialize** — target ship's 30s secrets sync sees the inactive bot assigned to it, activates it, starts it, and pushes the updated state.
+2. **Materialize** — target ship's 30s secrets sync sees the transit bot assigned to it, sets `status: "quarters"`, starts it, and pushes the updated state.
 
 Transport uses git (not Matrix) because it must survive relay restarts and network blips. If the target ship's relay missed a Matrix message, the bot would be lost. The git protocol guarantees delivery.
 
@@ -55,7 +64,7 @@ All metrics use rolling 1d/7d windows. No cumulative totals.
    *Check:* Pre-commit hook validates rank integrity and required fields.
 
 2. **Transport works** — `!transport cid poseidon` moves Cid to Poseidon.
-   *Check:* Cid dematerializes on source ship (status → transit), materializes on target ship (status → onduty). fleet.json updated and pushed.
+   *Check:* Cid dematerializes on source ship (status → transit), materializes on target ship (status → quarters). fleet.json updated and pushed.
 
 3. **Fleet command aggregates** — `!fleet` in any room.
    *Check:* Single response from speaker, includes data from all active ships.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,7 +20,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 ## Organization
 
 - `09-roles-and-rooms.md` — Roles, room topology, command hierarchy (Captain → Operator/Co → XO → Chiefs → Crew; Chief = highest-rank bot per room; Chief Navigator = XO), bot statuses (pip progression: 🟢/📝/💤/✅ for onduty/retrospective/dream/ready), lifecycle commands (!wake/!sleep/!report/!dismiss/!go), quarters trigger rules, quarters as retrospective memory space, duty cycle (quarters→onduty→retrospective→sleep→dream→ready, ondutyAt in fleet.json, no resync while on duty)
-- `10-fleet.md` — fleet.json, transport protocol, S3 coordination, fleet metrics (availability, autonomy score)
+- `10-fleet.md` — fleet.json schema (role/rank/ship/status/triggerType/quartersRoom/activeBrainModel/ondutyAt), transport protocol (transit→quarters on materialize), S3 coordination, fleet metrics (availability, autonomy score)
 - `11-commands.md` — X-commands (`!`-prefixed fleet control), room-scoped targeting (presence-based for most commands, assignment-based for !report, universal from BTC), `!pull [ship]` (no arg = all ships) / `!push [ship]` commands, `!operator` toggle, `!metrics` (context-aware, 1d/7d rolling), status formats, alert threads. `!rejoin` and `!refresh` removed — `!wake` handles both restart and wake.
 - `12-co.md` — Chain of command (CO/XO/Chief), Chief election and delegation, Work Breakdown Structure (WBS) — per-room task list with dependencies, auto-assignment on bot startup, reabsorption on off-duty
 - `13-intercom.md` — Intercom accounts (bridge/engineering/astrometrics), loudspeaker replies (`[emoji Ship]` prefix), `@loudspeaker:` bot broadcast (implemented), `@room:` targeted routing (not yet implemented)


### PR DESCRIPTION
## Summary
- **Transport status bug**: doc said materialization sets `status: "onduty"` — code (`relay.ts:2149`) sets `status: "quarters"`. Fixed in two places (description + verification check).
- **Schema example**: added optional `BotEntry` fields missing from the example: `triggerType`, `quartersRoom`, `activeBrainModel`, `ondutyAt`
- Updated README.md index

## Design reference
[10-fleet.md](docs/design/10-fleet.md), `src/ship-config.ts` `BotEntry` interface