### PR TITLE
docs: update 03-container.md for branch brain containers and CONTAINER_IMAGE

### DIFF
--- a/docs/design/03-container.md
+++ b/docs/design/03-container.md
@@ -9,7 +9,7 @@ An InfiniClaw container acts like a mini-OS:
 2.  **The Main Brain (Trunk):** A persistent `claude-code` process spawned by the agent runner for triage and management. It does NOT restart per message — it stays running and receives new messages via IPC.
 3.  **Async Lobes (Workers):** Stateless subprocesses (Codex, Gemini, Claude, Ollama) spawned by the delegate runner for fast parallel execution. Results returned via IPC files.
 
-**Branch brains** run on the host (not inside containers). The relay spawns them as `claude --print` processes that communicate via Matrix threads. See [08-threading](08-threading.md).
+**Branch brains** run as isolated podman containers (`bots/container/branch-brain/Dockerfile`) with `--network none` and credentials passed as `--env` args. Falls back to host `claude --print` if `BRANCH_BRAIN_IMAGE` is unset. See [08-threading](08-threading.md).
 
 This architecture ensures the bot is always reachable on the main timeline regardless of how many complex tasks are running in parallel.
 
@@ -19,7 +19,9 @@ Each bot has a Dockerfile at `bots/{role}/{persona}/Dockerfile` (e.g. `bots/engi
 
 Build flow: `bots/build.sh {bot}` discovers the Dockerfile, builds with `bots/container/` as context, tags as `nanoclaw-{bot}:latest`.
 
-Images are rebuilt automatically on deploy by hashing the Dockerfile + agent-runner contents.
+Images are rebuilt automatically on deploy by hashing the Dockerfile + agent-runner contents. The image name is controlled by `CONTAINER_IMAGE` (from NanoClaw's `nanoclaw/config.js`).
+
+**Branch brain image** — `bots/container/branch-brain/Dockerfile` is a separate minimal image (`node:22-slim` + claude CLI, no agent-runner). Built independently and referenced via `BRANCH_BRAIN_IMAGE` env var (default: `localhost/infiniclaw-branch-brain:latest`). Must be built manually: `podman build -t localhost/infiniclaw-branch-brain:latest bots/container/branch-brain/`.
 
 ## Mount System
 
@@ -49,7 +51,7 @@ Two-tier design: read-only everywhere, write access where needed.
 ## Secrets
 
 - **No credentials in git.** Bot env files live in the secrets repo (`~/.config/infiniclaw/secrets/`). `.mcp.json` files (may contain OAuth tokens) are gitignored.
-- **Secrets flow:** Profile env files → loaded by host process → written to a mounted env file at `/workspace/env-dir/env` (read-only inside container). The entrypoint sources this file. `CONTAINER_ENV_*` vars are injected separately as `-e` flags with the prefix stripped.
+- **Secrets flow:** Profile env files → loaded by host process → written to a mounted env file at `/workspace/env-dir/env` (read-only inside container). The entrypoint sources this file. `CONTAINER_ENV_*` vars are injected separately as `-e` flags with the prefix stripped (e.g. `CONTAINER_ENV_FOO=bar` → `-e FOO=bar` inside the container).
 - **Credential allowlist:** Only a fixed set of permitted keys are written to the container env file — `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_MODEL`, and a small set of other required keys. All other host env vars are excluded. See [#37](https://github.com/wawiesel/InfiniClaw/issues/37).
 - **Mount allowlist** is stored outside the repo (`~/.config/infiniclaw/allow-list.json`) so containers can't tamper with it.
 - **Cert mapping:** Host CA cert paths are mapped to container-compatible locations for Node, Python, curl, and git (`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,7 +7,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 - `00-overview.md` — Definitions (fleet, ship, relay, bot, operator, space, room, duty room), core principles, code structure
 - `01-operator.md` — Operator as escape hatch (host-side tmux, max intelligence, idle in mature fleet), bootstrap foundations (Matrix + S3 + secrets → BehindTheCurtain → first ship → first bot), accounts, Captain communication (all ships with operatorRelay=true receive BTC; !operator on/off per ship), inter-operator inbox, x-commands, operating modes (📡 Watch/👑 Captain/🔧 Fix with mode icon in message prefix), autonomy metrics (interventions/day, 1d/7d rolling)
 - `02-matrix.md` — Matrix server, accounts, room naming convention (double-emoji on all rooms and spaces), ship spaces (example not prescriptive), room setup (m.space.child + m.space.parent both required), message format, `<m>` mention pills, reactions (📡/👀/🔔 status pipeline, 👍️/👎️/💯/❌️ scoring), special mentions (@operator, @loudspeaker broadcast/fleet-status, @room intercom), bot Matrix navigation tools, verification
-- `03-container.md` — Persistent Podman containers (one per bot, not per turn), internal concurrency (agent runner + persistent main brain + lobes), branch brains on host, image builds, mount table (corrected runtime paths), secrets flow (credential allowlist, not proxy — #37)
+- `03-container.md` — Persistent Podman containers (one per bot, not per turn), internal concurrency (agent runner + persistent main brain + lobes), branch brains in containers (BRANCH_BRAIN_IMAGE, bots/container/branch-brain/Dockerfile), image builds (CONTAINER_IMAGE), mount table, secrets flow (CONTAINER_ENV_* prefix stripping, credential allowlist — #37)
 
 ## Bot Runtime
 


### PR DESCRIPTION
## Summary
- "Branch brains run on the host" — outdated after PR #65; now run in podman containers
- Add branch brain image section: `bots/container/branch-brain/Dockerfile`, `BRANCH_BRAIN_IMAGE`, manual build command
- Add note on `CONTAINER_IMAGE` (sourced from `nanoclaw/config.js`)
- Clarify `CONTAINER_ENV_*` with concrete example (`CONTAINER_ENV_FOO=bar` → `-e FOO=bar`)
- Updated README.md index

## Design reference
[03-container.md](docs/design/03-container.md)