### PR TITLE
docs: review 13-intercom.md — @loudspeaker alone = fleet status

### DIFF
--- a/docs/design/13-intercom.md
+++ b/docs/design/13-intercom.md
@@ -26,6 +26,8 @@ Operators on each ship use intercom to issue x-commands that all relays receive.
 
 Any on-duty bot can broadcast to all duty rooms via `@loudspeaker: <message>`. The relay detects this pattern, sends to all other duty rooms, and replies with confirmation. Messages appear as `BotName (SourceRoom): <message>`. Captain and operator messages are excluded from this path.
 
+`@loudspeaker` alone (no message) triggers a `!fleet` status response in that room.
+
 > **Status:** `@room:` targeting (sending to a specific room) is not yet implemented — `@loudspeaker:` broadcasts to all duty rooms only. See [02-matrix](02-matrix.md).
 
 ### Relays → Rooms

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -23,7 +23,7 @@ Architecture and design specifications for InfiniClaw. Documents are ordered by 
 - `10-fleet.md` — fleet.json schema (role/rank/ship/status/triggerType/quartersRoom/activeBrainModel/ondutyAt), transport protocol (transit→quarters on materialize), S3 coordination, fleet metrics (availability, autonomy score)
 - `11-commands.md` — X-commands (`!`-prefixed fleet control), room-scoped targeting (presence-based for most commands, assignment-based for !report, universal from BTC), `!pull [ship]` (no arg = all ships) / `!push [ship]` commands, `!operator` toggle, `!metrics` (context-aware, 1d/7d rolling), status formats, alert threads. `!rejoin` and `!refresh` removed — `!wake` handles both restart and wake.
 - `12-co.md` — Chain of command (CO/XO/Chief), Chief election and delegation, Work Breakdown Structure (WBS) — per-room task list with dependencies, auto-assignment on bot startup, reabsorption on off-duty
-- `13-intercom.md` — Intercom accounts (bridge/engineering/astrometrics), loudspeaker replies (`[emoji Ship]` prefix), `@loudspeaker:` bot broadcast (implemented), `@room:` targeted routing (not yet implemented)
+- `13-intercom.md` — Intercom accounts (bridge/engineering/astrometrics), loudspeaker replies (`[emoji Ship]` prefix), `@loudspeaker:` bot broadcast / `@loudspeaker` alone = fleet status (both implemented), `@room:` targeted routing (not yet implemented)
 
 ## Resilience
 


### PR DESCRIPTION
## Summary
- `@loudspeaker` alone (no message) triggers `!fleet` status in that room — implemented in relay.ts but undocumented
- Updated README.md index entry to mention both behaviors

## Verification
`relay.ts` line ~3928-3933: when `lsCallout[1]` is undefined (no message), calls `handleCommand('!fleet', ...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)