### PR TITLE
docs: review 07-ipc.md — fix poll interval, add wbs_complete relay task

### DIFF
--- a/docs/design/07-ipc.md
+++ b/docs/design/07-ipc.md
@@ -60,6 +60,7 @@ Relay-task types written to `_runtime/relay-tasks/*.json` (processed by relay, n
 |-----------|--------|
 | `git_push` | Push branches to remote (requires host git credentials) |
 | `branch_brain` | Spawn a branch brain in a new thread |
+| `wbs_complete` | Signal that a bot completed a WBS item (unblocks dependents) |
 
 ## Per-Room Namespaces
 
@@ -71,7 +72,7 @@ Only the main room's containers can run privileged IPC commands (`refresh_bot`, 
 
 ## Processing
 
-The host's `ipc-watcher.ts` polls IPC directories every 500ms. Relay-tasks are polled every 2s. Files are processed atomically:
+The host's `ipc-watcher.ts` polls IPC directories every 1s. Relay-tasks are polled every 2s. Files are processed atomically:
 
 1. Rename `*.json` → `*.processing`
 2. Parse and execute the command


### PR DESCRIPTION
## Summary
- `IPC_POLL_INTERVAL` in `nanoclaw/src/config.ts` is 1000ms (1s), not 500ms as documented
- `relayTasksLoop` in relay.ts handles `wbs_complete` (unblocks WBS dependents) — missing from relay-tasks table

## Verification
- `external/nanoclaw/src/config.ts:54`: `export const IPC_POLL_INTERVAL = 1000`
- `relay.ts` line ~1993: `else if (data['type'] === 'wbs_complete')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)