### PR TITLE
fix(#118): enforce quarters-only for normie-role bots

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -45,7 +45,7 @@ Host machine (macOS / Linux)
 ├── channels/
 │   └── matrix.ts       → Matrix SDK: connect, send, edit, react, sync, mention pills
 ├── infini-config.ts    → InfiniClaw-specific env config (removed from upstream)
-├── ship-config.ts      → Fleet/ship config, shared constants. `ROLE_ROOMS` is the single source of truth for role→duty room→icon (navigator/engineer/architect/normie). `ShipEntry` includes type/typeEmoji for ship classification. `shipTag()` returns emoji+pip+name (🦁🟢 Herc) with auto-derived or caller-supplied status pip. `findShipByHostname()` resolves hostname→ship entry.
+├── ship-config.ts      → Fleet/ship config, shared constants. `ROLE_ROOMS` is the single source of truth for role→duty room→icon (navigator/engineer/architect/normie). `ShipEntry` includes type/typeEmoji for ship classification. `shipTag()` returns emoji+pip+name (🦁🟢 Herc) with auto-derived or caller-supplied status pip. `findShipByHostname()` resolves hostname→ship entry. `isQuartersOnlyRole(role)` returns true when the role's `rw` list in fleet.json is absent or empty — used by `!report` to prevent normie-style bots from joining duty rooms (engineering/bridge/astrometrics).
 ├── allow-list.ts       → Validate mounts against host-side allowlist (~/.config/infiniclaw/allow-list.json)
 ├── ipc-watcher.ts      → Poll IPC output dir for container commands
 ├── ipc-commands.ts     → Handle refresh_bot, stop_bot, send_reaction, rebuild_image, git_push, etc.

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -39,7 +39,7 @@ import {
   clearIntercomConfigCache,
 } from './matrix-api.js';
 import type { IntercomConfig, SyncResponse } from './matrix-api.js';
-import { loadShipConfig, loadFleet, writeFleet, loadShips, safeLoadShips, writeShips, isShipCommissioned, clearShipConfigCache, RUNNING_STATUSES, shipTag, findShipByHostname, thisShipName, ROLE_ROOMS } from './ship-config.js';
+import { loadShipConfig, loadFleet, writeFleet, loadShips, safeLoadShips, writeShips, isShipCommissioned, clearShipConfigCache, RUNNING_STATUSES, shipTag, findShipByHostname, thisShipName, ROLE_ROOMS, isQuartersOnlyRole } from './ship-config.js';
 import type { BotStatus as BotStatusType } from './ship-config.js';
 import { capitalizeName, formatBotDisplayName, PIP_FOR_STATUS, ROLE_ICONS, botBadge, isBotCO, rankMedal, shipHeaderLine, unifiedShipDisplay, botTreeLine, unifiedBotDisplay } from './formatting.js';
 import {
@@ -2808,6 +2808,13 @@ async function handleLifecycleCommand(
       }
       if (liveFleet[bot]?.status === 'onduty') {
         await tr(`⚠️ ${name} already on duty`);
+        continue;
+      }
+      // Normie enforcement (#118): bots whose role has rw:[] in fleet.json roles
+      // have no duty-room access and must stay in quarters.
+      const botRole = liveFleet[bot]?.role?.toLowerCase() ?? '';
+      if (isQuartersOnlyRole(botRole)) {
+        await tr(`⚠️ ${name} has no duty room (quarters only)`);
         continue;
       }
       try {

--- a/src/ship-config.ts
+++ b/src/ship-config.ts
@@ -244,6 +244,21 @@ export function shipTag(hostname?: string, pip?: string): string {
   return entry.emoji ? `${entry.emoji}${statusPip} ${name}` : `${statusPip} ${name}`;
 }
 
+/**
+ * Returns true if the given role has no duty-room access — i.e. its `rw` list
+ * in the fleet.json `roles` section is absent or empty.  Bots with such roles
+ * (e.g. normie) must never join duty rooms; they are quarters-only.
+ */
+export function isQuartersOnlyRole(role: string): boolean {
+  try {
+    const raw = readJson<Record<string, unknown>>(FLEET_PATH);
+    const roleConfig = (raw.roles as Record<string, { rw?: string[] }> | undefined)?.[role];
+    return !roleConfig?.rw || roleConfig.rw.length === 0;
+  } catch {
+    return false; // on error, don't block
+  }
+}
+
 /** Clear cached config (for testing or reload). */
 export function clearShipConfigCache(): void {
   cached = null;


### PR DESCRIPTION
Closes #118

Adds `isQuartersOnlyRole()` to `ship-config.ts`; guards the `!report` handler in `relay.ts` so bots with `rw:[]` in fleet.json roles skip duty rooms with a clear warning.

## Changes
- `ship-config.ts`: export `isQuartersOnlyRole(role)` - returns true when fleet.json roles[role].rw is absent/empty
- `relay.ts`: check `isQuartersOnlyRole` in `!report` handler before moving bot to duty room
- `src/README.md`: document the new helper