### PR TITLE
feat: Branch Brain uses --fork-session to inherit bot context

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1156,6 +1156,10 @@ async function runAgent(
     if (output.newSessionId && output.status !== 'error') {
       sessions[group.folder] = output.newSessionId;
       setSession(group.folder, output.newSessionId);
+      // Persist session ID to file so relay can use --fork-session for Branch Brains (#81).
+      if (group.folder === MAIN_GROUP_FOLDER) {
+        try { fs.writeFileSync(path.join(DATA_DIR, 'current-session-id'), output.newSessionId); } catch { /* best-effort */ }
+      }
     }
 
     if (output.status === 'error') {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -2025,16 +2025,39 @@ async function spawnBranchBrain(
     });
     log(`branchBrain: spawning in container image=${BRANCH_BRAIN_IMAGE} session=${sessionId}`);
   } else {
-    log(`branchBrain: BRANCH_BRAIN_IMAGE unset — falling back to host spawn session=${sessionId}`);
-    child = spawn('claude', [
-      '--verbose',
-      '--dangerously-skip-permissions',
-      '--output-format', 'stream-json',
-      '--add-dir', resolveRoot(),
-    ], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: childEnv,
-    });
+    // Prefer --fork-session so BB inherits the bot's full conversation context (#81).
+    // Falls back to cold context if no session ID file exists yet.
+    const sessionFile = bot
+      ? path.join(resolveRoot(), '_runtime', 'instances', bot, 'data', 'current-session-id')
+      : '';
+    let botSessionId = '';
+    if (sessionFile) { try { botSessionId = fs.readFileSync(sessionFile, 'utf-8').trim(); } catch { /* no file yet */ } }
+
+    if (botSessionId) {
+      log(`branchBrain: BRANCH_BRAIN_IMAGE unset — forking from bot session=${botSessionId.slice(0, 8)}... bb=${sessionId}`);
+      child = spawn('claude', [
+        '--resume', botSessionId,
+        '--fork-session',
+        '--verbose',
+        '--dangerously-skip-permissions',
+        '--output-format', 'stream-json',
+        '--add-dir', resolveRoot(),
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: childEnv,
+      });
+    } else {
+      log(`branchBrain: BRANCH_BRAIN_IMAGE unset — falling back to host spawn session=${sessionId}`);
+      child = spawn('claude', [
+        '--verbose',
+        '--dangerously-skip-permissions',
+        '--output-format', 'stream-json',
+        '--add-dir', resolveRoot(),
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: childEnv,
+      });
+    }
   }
 
   // Write initial prompt and keep stdin open for context injection.


### PR DESCRIPTION
## Summary

- On each completed main-brain turn, write session ID to `_runtime/instances/<bot>/data/current-session-id`
- In `spawnBranchBrain` (host path), read that file and spawn BB with `--resume <id> --fork-session`
- BB now inherits full conversation history — no cold start, no context re-establishment needed
- Falls back to cold `--print` spawn if no session file exists (first bot turn, fresh deploy)
- Container spawn path unchanged

## Why --fork-session

`--fork-session` creates a new independent session that starts from the parent session's conversation history. The parent session continues unaffected. BB gets the context without competing with the main brain.

## Test Plan
- [ ] Start bot, trigger a branch brain → verify log shows `spawning with --fork-session`
- [ ] Verify BB output references context from main conversation (not cold start)
- [ ] Fresh bot (no session file) → verify fallback to cold spawn
- [ ] Container mode (`BRANCH_BRAIN_IMAGE` set) → unchanged behavior

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)