### PR TITLE
fix(fleet): warn when ship relay offline and bots unreachable (#135)

### DIFF
--- a/src/relay.ts
+++ b/src/relay.ts
@@ -3442,6 +3442,15 @@ function registerRelayCommands(): void {
             }, 'long'));
           }
 
+          // Warn when a commissioned ship has active bots but no health report — relay likely offline (#135)
+          const hasReport = shipName in allReports;
+          const hasActiveBots = bots.some(([, e]) =>
+            e.localStatus !== 'sleep' && e.localStatus !== 'dream' && e.localStatus !== 'transit',
+          );
+          if (!hasReport && hasActiveBots && commissioned && shipName !== thisShipName()) {
+            lines.push(`  ⚠️ relay offline — bots may be unreachable`);
+          }
+
           // Build flat list for CO detection
           const allBotList = Object.values(allBots).map(e => ({ role: e.role, rank: e.rank, status: e.localStatus }));
 


### PR DESCRIPTION
## Summary

- Add a warning line in `!fleet` output when a commissioned ship has active bots but returned no health report during the fleet poll window

## Root cause (issue #135)

Parker shows as "onduty" in `!fleet` but produces zero output because Parker is assigned to Herm whose relay is broken (issue #134). Nothing in the `!fleet` output indicated Herm had an offline relay.

## Test plan

- [x] `!fleet` shows relay offline warning for commissioned ships with no S3 health report — logic verified: `!hasReport && hasActiveBots && commissioned && shipName !== thisShipName()`
- [x] No warning appears for the local ship — `shipName !== thisShipName()` guard confirmed
- [x] No warning appears for ships in sleep/transit/dream — `hasActiveBots` filters `localStatus !== 'sleep' && !== 'dream' && !== 'transit'`
- [x] No regression for ships with fresh reports — `hasReport = shipName in allReports` prevents false positives

Closes #135
