### PR TITLE
fix: use podman for scheduled task container spawns (#149)

### DIFF
--- a/external/nanoclaw/src/README.md
+++ b/external/nanoclaw/src/README.md
@@ -13,7 +13,7 @@ Clean fork of [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw). Platfor
 | `db.ts` | SQLite message/chat/group store |
 | `group-queue.ts` | Per-group container queue — serializes agent runs, IPC piping, fair slot scheduling |
 | `container-runner.ts` | Spawns podman containers for agent runs |
-| `container-runtime.ts` | Container runtime detection |
+| `container-runtime.ts` | Container runtime config — `CONTAINER_RUNTIME_BIN` set to `podman` (InfiniClaw uses podman, not docker) |
 | `credential-proxy.ts` | Credential proxy for secure secret injection |
 | `ipc.ts` | IPC watcher — task/message/context dirs |
 | `task-scheduler.ts` | Cron/interval task scheduler |

--- a/external/nanoclaw/src/container-runtime.ts
+++ b/external/nanoclaw/src/container-runtime.ts
@@ -9,7 +9,7 @@ import os from 'os';
 import { logger } from './logger.js';
 
 /** The container runtime binary name. */
-export const CONTAINER_RUNTIME_BIN = 'docker';
+export const CONTAINER_RUNTIME_BIN = 'podman';
 
 /** Hostname containers use to reach the host machine. */
 export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';


### PR DESCRIPTION
## Summary
- Change `CONTAINER_RUNTIME_BIN` from `'docker'` to `'podman'` in `external/nanoclaw/src/container-runtime.ts`
- Fixes scheduled tasks (heartbeat nudges) silently failing with ENOENT

## Root cause
InfiniClaw uses podman, not docker. The InfiniClaw `container-spawn.ts` correctly overrides `runtime: 'podman'` for message-triggered spawns. But scheduled tasks go through upstream NanoClaw's `task-scheduler.ts` → `runContainerAgent()` → `container-runner.ts` which used the upstream `CONTAINER_RUNTIME_BIN = 'docker'`.

Result: every heartbeat nudge failed with `ENOENT: spawn docker`, silently breaking the autonomy loop.

Closes #149

## Test plan
- [x] 258 tests pass
- [ ] After `!pull`, verify heartbeat nudge spawns succeed (check log for `Spawning container agent` without `Container spawn error`)