### PR TITLE
fix: default CONTAINER_RUNTIME_BIN to podman, allow env override

### DIFF
--- a/external/nanoclaw/src/README.md
+++ b/external/nanoclaw/src/README.md
@@ -13,7 +13,7 @@ Clean fork of [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw). Platfor
 | `db.ts` | SQLite message/chat/group store |
 | `group-queue.ts` | Per-group container queue — serializes agent runs, IPC piping, fair slot scheduling |
 | `container-runner.ts` | Spawns podman containers for agent runs |
-| `container-runtime.ts` | Container runtime detection |
+| `container-runtime.ts` | Container runtime detection; defaults to `podman`, overridable via `CONTAINER_RUNTIME_BIN` env var |
 | `credential-proxy.ts` | Credential proxy for secure secret injection |
 | `ipc.ts` | IPC watcher — task/message/context dirs |
 | `task-scheduler.ts` | Cron/interval task scheduler |

--- a/external/nanoclaw/src/container-runtime.ts
+++ b/external/nanoclaw/src/container-runtime.ts
@@ -8,8 +8,8 @@ import os from 'os';
 
 import { logger } from './logger.js';
 
-/** The container runtime binary name. */
-export const CONTAINER_RUNTIME_BIN = 'docker';
+/** The container runtime binary name. Defaults to podman; override via CONTAINER_RUNTIME_BIN env var. */
+export const CONTAINER_RUNTIME_BIN = process.env.CONTAINER_RUNTIME_BIN ?? 'podman';
 
 /** Hostname containers use to reach the host machine. */
 export const CONTAINER_HOST_GATEWAY = 'host.docker.internal';


### PR DESCRIPTION
## Summary
- `CONTAINER_RUNTIME_BIN` in `external/nanoclaw/src/container-runtime.ts` was hardcoded to `'docker'`
- InfiniClaw uses podman — scheduled tasks (heartbeat nudges) were failing with `ENOENT: spawn docker`
- Now defaults to `'podman'`; override via `CONTAINER_RUNTIME_BIN` env var for docker environments

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)